### PR TITLE
SDK version update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,13 +11,17 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion '27.0.3'
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion  safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Cause the upgrade of ReactNative's Android SDK version, this compileSdkVersion would be incompatible with the app built by newer RN framework. So, it would be better to get SDK version from app developers dynamically.